### PR TITLE
Check if user was returned

### DIFF
--- a/src/callback-endpoint.ts
+++ b/src/callback-endpoint.ts
@@ -57,6 +57,11 @@ export const createCallbackEndpoint = (
       const userInfo = await pluginOptions.getUserInfo(access_token);
 
       // /////////////////////////////////////
+      // check if user was returned
+      // /////////////////////////////////////
+      if (userInfo === null) throw new Error(`No User Info`);
+
+      // /////////////////////////////////////
       // ensure user exists
       // /////////////////////////////////////
 


### PR DESCRIPTION
Checks if the user was returned from the getUserInfo function before trying to create an account and login.

This allows us to do an extra verification step inside the getUserInfo function in the config file.

An example where this might be useful is when you only want to allow accounts from a specific google organization to login, this could now be achieved with the following:

```
getUserInfo: async (accessToken: string) => {
  const response = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
    headers: { Authorization: `Bearer ${accessToken}` },
  });
  const user = await response.json();

  // Only allow users from a specific organization to login
  if (!user.hd || user.hd !== 'organization.com') return null;

  return { email: user.email, sub: user.sub };
},
```

Feel free to close this pull request if you do not feel like it is needed.