### PR TITLE
feat: use payload's token extraction logic

### DIFF
--- a/src/auth-strategy.ts
+++ b/src/auth-strategy.ts
@@ -5,7 +5,7 @@ import {
   AuthStrategyResult,
   CollectionSlug,
   User,
-  parseCookies,
+  extractJWT,
 } from "payload";
 import { PluginOptions } from "./types";
 
@@ -17,8 +17,7 @@ export const createAuthStrategy = (
     name: pluginOptions.strategyName,
     authenticate: async ({ headers, payload }): Promise<AuthStrategyResult> => {
       try {
-        const cookie = parseCookies(headers);
-        const token = cookie.get(`${payload.config.cookiePrefix}-token`);
+        const token = extractJWT({ headers, payload })
         if (!token) return { user: null };
 
         let jwtUser: JWTPayload | null = null;


### PR DESCRIPTION
Currently you can only interact with the API using the payload cookie. 

By using payload's [extractJWT](https://github.com/payloadcms/payload/blob/c094b0e52035109eff26ec92d441b229ba474f17/packages/payload/src/auth/extractJWT.ts#L47) funcion in the authentication strategy, you can now use JWT tokens in the `Authorization` header to authenticate as well.