### PR TITLE
Additional flexibility to resolve user identity

### DIFF
--- a/src/auth-strategy.ts
+++ b/src/auth-strategy.ts
@@ -4,7 +4,7 @@ import {
   AuthStrategy,
   AuthStrategyResult,
   CollectionSlug,
-  User,
+  TypedUser as User,
   extractJWT,
 } from "payload";
 import { PluginOptions } from "./types";
@@ -49,8 +49,10 @@ export const createAuthStrategy = (
           pluginOptions.authCollection ||
           "users") as CollectionSlug;
         let user: User | null = null;
-
-        if (pluginOptions.useEmailAsIdentity) {
+        if (pluginOptions.resolveUserIdentity) {
+          user = await pluginOptions.resolveUserIdentity(jwtUser, payload);
+          return { user };
+        } else if (pluginOptions.useEmailAsIdentity) {
           if (!jwtUser.email || typeof jwtUser.email !== "string") {
             payload.logger.warn(
               "Using email as identity but no email is found in jwt token",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import type { PayloadRequest, TextField } from "payload";
+import type {
+  BasePayload,
+  PayloadRequest,
+  TextField,
+  TypedUser,
+} from "payload";
 
 export interface PluginOptions {
   /**
@@ -243,7 +248,32 @@ export interface PluginOptions {
    * If its not provided default will be used.
    * Reference: `defaultGetPkceCodes` in `src/default-get-pkce-codes.ts`
    */
-  getPkceCodes?: () => { verifier: string, challenge: string, challengeMethod: string };
+  getPkceCodes?: () => {
+    verifier: string;
+    challenge: string;
+    challengeMethod: string;
+  };
+
+  /**
+   * Function to resolve user identity.
+   * If its provided it will be used instead of the default behavior (useEmailAsIdentity or subFieldName).
+   * This function should return a promise that resolves to the user object
+   * or null if the user is not found.
+   * @param jwtUser The user object decoded from the JWT token
+   * @param payload BasePayload object
+   * @returns Promise that resolves to the TypedUser object or null if the user is not found
+   * @default undefined
+   */
+  resolveUserIdentity?: (
+    jwtUser: Record<string, unknown>,
+    payload: BasePayload,
+  ) => Promise<
+    | ({
+        _strategy?: string;
+        collection?: string;
+      } & TypedUser)
+    | null
+  >;
 }
 
 export interface NewCollectionTypes {


### PR DESCRIPTION
# Additional flexibility to resolve user identity

Add support for a `resolveUserIdentity` callback option to enable more flexible user resolution. This allows JWT values to be transformed (e.g. hashed) before being used, which cannot be handled reliably with the current approach.