### PR TITLE
fix: handle Next RSC authorize probes

### DIFF
--- a/.github/instructions/troubleshooting-nextjs-rsc-oauth-authorize.instructions.md
+++ b/.github/instructions/troubleshooting-nextjs-rsc-oauth-authorize.instructions.md
@@ -1,0 +1,27 @@
+---
+description: "Troubleshooting Next.js App Router RSC fetch failures when starting OAuth through the authorize endpoint."
+applyTo: "src/authorize-endpoint.ts,src/modify-auth-collection.ts,README.md,dev/**,examples/**"
+---
+
+# Next.js RSC fetch failure on OAuth authorize
+
+## Symptoms
+
+- Browser console logs `Failed to fetch RSC payload for .../api/<auth-collection>/oauth/authorize. Falling back to browser navigation.`
+- The OAuth login still continues after the fallback, usually by navigating to the provider authorization URL.
+
+## Root cause
+
+- The authorize endpoint is a Payload API endpoint that returns an HTTP redirect (`302`) to the external OAuth provider, not a Next.js App Router page or RSC payload.
+- When application UI starts login with Next client routing (`next/link` or `router.push`) to that same-origin API URL, Next tries to fetch an RSC payload first. The redirect/API response cannot satisfy that RSC request, so Next logs the fetch failure before falling back to full browser navigation.
+
+## Fix
+
+- Start OAuth with a document navigation instead of Next client routing: use a plain `<a href="/api/users/oauth/authorize">`, a form/action, or `window.location.assign('/api/users/oauth/authorize')`.
+- Do not use `next/link` or `router.push()` for the authorize endpoint. `prefetch={false}` may reduce prefetching, but it does not turn the click into a document navigation.
+
+## Verification
+
+- Click the login control and confirm the browser navigates directly to `/api/<auth-collection>/oauth/authorize` and follows the provider redirect.
+- Confirm the console no longer emits the RSC payload fetch failure during login.
+- Confirm the OAuth callback still completes and authenticates the user.

--- a/.github/instructions/troubleshooting-nextjs-rsc-oauth-authorize.instructions.md
+++ b/.github/instructions/troubleshooting-nextjs-rsc-oauth-authorize.instructions.md
@@ -13,15 +13,16 @@ applyTo: "src/authorize-endpoint.ts,src/modify-auth-collection.ts,README.md,dev/
 ## Root cause
 
 - The authorize endpoint is a Payload API endpoint that returns an HTTP redirect (`302`) to the external OAuth provider, not a Next.js App Router page or RSC payload.
-- When application UI starts login with Next client routing (`next/link` or `router.push`) to that same-origin API URL, Next tries to fetch an RSC payload first. The redirect/API response cannot satisfy that RSC request, so Next logs the fetch failure before falling back to full browser navigation.
+- When application UI starts login with Next client routing (`next/link` or `router.push`) to that same-origin API URL, Next tries to fetch an RSC payload first. If that probe follows the provider redirect, the fetch can fail before Next falls back to full browser navigation.
 
 ## Fix
 
-- Start OAuth with a document navigation instead of Next client routing: use a plain `<a href="/api/users/oauth/authorize">`, a form/action, or `window.location.assign('/api/users/oauth/authorize')`.
-- Do not use `next/link` or `router.push()` for the authorize endpoint. `prefetch={false}` may reduce prefetching, but it does not turn the click into a document navigation.
+- Prefer a document navigation for OAuth: use a plain `<a href="/api/users/oauth/authorize">`, a form/action, or `window.location.assign('/api/users/oauth/authorize')`.
+- The package should also defensively detect Next RSC probe requests (`RSC: 1`, `Next-Router-State-Tree`, `Next-Router-Prefetch`, or `_rsc`) and return `204 No Content` instead of the provider redirect. This lets Next fall back without the noisy failed-fetch log; the subsequent document navigation still receives the normal `302`.
+- `prefetch={false}` may reduce prefetching, but it does not turn a `next/link` click into a document navigation.
 
 ## Verification
 
-- Click the login control and confirm the browser navigates directly to `/api/<auth-collection>/oauth/authorize` and follows the provider redirect.
-- Confirm the console no longer emits the RSC payload fetch failure during login.
-- Confirm the OAuth callback still completes and authenticates the user.
+- Unit-test the authorize endpoint with Next RSC probe headers and assert `204` with no `Location` header.
+- Unit-test a normal authorize request and assert it still returns `302` with the provider authorization `Location`.
+- In a Next.js app, click the login control and confirm the OAuth flow redirects to the provider without the RSC payload fetch failure log, then returns through the callback and authenticates the user.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ pnpm install payload-oauth2
 
 If you are feeling adventurous and want to manage the plugin yourself, you can copy the `src` directory into your payload projects.
 
+# Starting the OAuth flow
+
+Create a normal browser navigation to the Payload authorize endpoint from your login UI:
+
+```tsx
+export function GoogleLoginButton() {
+  return <a href="/api/users/oauth/google">Continue with Google</a>
+}
+```
+
+In Next.js App Router apps, do not start OAuth with `next/link` or `router.push()` for the authorize endpoint. The endpoint returns a redirect to the OAuth provider, not a React Server Component payload, so client-side routing can briefly log `Failed to fetch RSC payload ... Falling back to browser navigation` before the login continues.
+
 # Contributing
 
 Contributions and feedback are very welcome.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export function GoogleLoginButton() {
 }
 ```
 
-In Next.js App Router apps, do not start OAuth with `next/link` or `router.push()` for the authorize endpoint. The endpoint returns a redirect to the OAuth provider, not a React Server Component payload, so client-side routing can briefly log `Failed to fetch RSC payload ... Falling back to browser navigation` before the login continues.
+In Next.js App Router apps, prefer not to start OAuth with `next/link` or `router.push()` for the authorize endpoint. The endpoint returns a redirect to the OAuth provider, not a React Server Component payload. The plugin defensively ignores Next.js RSC navigation probes so client routing can fall back without the noisy `Failed to fetch RSC payload ... Falling back to browser navigation` log, but normal document navigation is still the most direct option.
 
 # Contributing
 

--- a/src/authorize-endpoint.ts
+++ b/src/authorize-endpoint.ts
@@ -4,12 +4,22 @@ import { generateCookie } from "payload";
 import { defaultGetPkceCodes } from "./default-get-pkce-codes";
 import type { PluginOptions } from "./types";
 
+const isNextRscRequest = (req: PayloadRequest): boolean =>
+  req.headers.get("RSC") === "1" ||
+  req.headers.has("Next-Router-State-Tree") ||
+  req.headers.has("Next-Router-Prefetch") ||
+  req.searchParams.has("_rsc");
+
 export const createAuthorizeEndpoint = (
   pluginOptions: PluginOptions,
 ): Endpoint => ({
   method: "get",
   path: pluginOptions.authorizePath || "/oauth/authorize",
   handler: async (req: PayloadRequest) => {
+    if (isNextRscRequest(req)) {
+      return new Response(null, { status: 204 });
+    }
+
     const clientId = pluginOptions.clientId;
     const authCollection = pluginOptions.authCollection || "users";
     const callbackPath = pluginOptions.callbackPath || "/oauth/callback";

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -105,6 +105,19 @@ describe("Google OAuth2 Plugin", () => {
       });
     });
 
+    it("should not redirect Next.js RSC navigation probes", async () => {
+      const pluginOptions = testSuite["getPluginOptions"]();
+      const authorizeEndpoint = createAuthorizeEndpoint(pluginOptions);
+      const mockRequest = testSuite.createAuthorizeRequest();
+      mockRequest.headers.set("RSC", "1");
+      mockRequest.headers.set("Next-Router-State-Tree", "[]");
+
+      const response = await authorizeEndpoint.handler(mockRequest);
+
+      expect((response as Response).status).toBe(204);
+      expect((response as Response).headers.get("Location")).toBeNull();
+    });
+
     it("should include state parameter when provided", async () => {
       const pluginOptions = testSuite["getPluginOptions"]();
       const authorizeEndpoint = createAuthorizeEndpoint(pluginOptions);


### PR DESCRIPTION
## Summary

- Return `204 No Content` for Next.js App Router RSC probe requests to the OAuth authorize endpoint.
- Preserve normal authorize requests as `302` redirects to the OAuth provider.
- Document the recommended document-navigation pattern and troubleshooting guidance.

## Root cause

Next.js App Router treats same-origin `/api/.../oauth/authorize` links created with `next/link` or `router.push()` as client navigations and first attempts to fetch an RSC payload. The Payload authorize endpoint normally returns a `302` redirect to the OAuth provider instead of an RSC response, so the RSC fetch can follow the external redirect and fail before Next falls back to browser navigation.

## Verification

- Added a failing Google authorize endpoint test that reproduced the current behavior: RSC probe requests received `302`.
- Added package-side defensive handling; the same test now passes with `204` and no `Location` header.
- `corepack pnpm test:google`
- `corepack pnpm test`
- `corepack pnpm build`
- `git diff --check`

Closes #3
