### PR TITLE
fix(auth): honor Payload sessions for OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,11 @@ Create a normal browser navigation to the Payload authorize endpoint from your l
 
 ```tsx
 export function GoogleLoginButton() {
-  return <a href="/api/users/oauth/google">Continue with Google</a>;
+  return <a href="/api/users/oauth/google">Continue with Google</a>
 }
 ```
 
 In Next.js App Router apps, prefer not to start OAuth with `next/link` or `router.push()` for the authorize endpoint. The endpoint returns a redirect to the OAuth provider, not a React Server Component payload. The plugin defensively ignores Next.js RSC navigation probes so client routing can fall back without the noisy `Failed to fetch RSC payload ... Falling back to browser navigation` log, but normal document navigation is still the most direct option.
-
-# Payload auth sessions
-
-For Payload's standard session lifecycle (`auth.useSessions: true` with the local JWT strategy enabled), OAuth logins create a Payload session and sign its `sid` into the `payload-token` cookie. Later auth requests validate that `sid` against `user.sessions`, so Payload refresh works after OAuth login and logout/session revocation is honored.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ Create a normal browser navigation to the Payload authorize endpoint from your l
 
 ```tsx
 export function GoogleLoginButton() {
-  return <a href="/api/users/oauth/google">Continue with Google</a>
+  return <a href="/api/users/oauth/google">Continue with Google</a>;
 }
 ```
 
 In Next.js App Router apps, prefer not to start OAuth with `next/link` or `router.push()` for the authorize endpoint. The endpoint returns a redirect to the OAuth provider, not a React Server Component payload. The plugin defensively ignores Next.js RSC navigation probes so client routing can fall back without the noisy `Failed to fetch RSC payload ... Falling back to browser navigation` log, but normal document navigation is still the most direct option.
+
+# Payload auth sessions
+
+For Payload's standard session lifecycle (`auth.useSessions: true` with the local JWT strategy enabled), OAuth logins create a Payload session and sign its `sid` into the `payload-token` cookie. Later auth requests validate that `sid` against `user.sessions`, so Payload refresh works after OAuth login and logout/session revocation is honored.
 
 # Contributing
 

--- a/docs/instructions/troubleshooting-payload-auth-sessions.instructions.md
+++ b/docs/instructions/troubleshooting-payload-auth-sessions.instructions.md
@@ -1,0 +1,33 @@
+---
+description: "Troubleshooting Payload v3 auth session issues in the OAuth2 auth strategy and callback flow."
+applyTo: "src/auth-strategy.ts,src/callback-endpoint.ts,src/auth-sessions.ts,test/**,README.md"
+---
+
+# Payload auth sessions with OAuth2
+
+## Symptoms
+
+- Payload refresh fails or returns forbidden after OAuth login when `auth.useSessions` is enabled.
+- Logging out removes the Payload session, but restoring an old `payload-token` cookie still authenticates.
+- Captured JWTs remain valid until `tokenExpiration` even after logout.
+
+## Root cause
+
+- Payload v3 session-backed JWTs include a `sid` claim that must match an entry in `user.sessions`.
+- The OAuth2 callback previously signed Payload JWTs without creating a session or including `sid`.
+- The OAuth2 auth strategy verified Payload JWTs independently and returned users by email/sub without validating `sid`.
+- Because custom auth strategies run before Payload's built-in `local-jwt` strategy, the OAuth2 strategy could bypass Payload's native session revocation.
+
+## Fix
+
+- When Payload sessions are active for the auth collection, create a Payload session during OAuth callback and include its `sid` in the signed JWT.
+- In the OAuth2 auth strategy, require `sid` for session-backed collections and validate it against `user.sessions` before returning a user.
+- Set `user._sid` after validation so Payload refresh/logout operations can use the session ID.
+- Do not create users from JWT authentication when sessions are active.
+
+## Verification
+
+- Unit-test OAuth callback to confirm a session is persisted and the generated JWT contains `sid`.
+- Unit-test the auth strategy with a valid `sid`, missing `sid`, and revoked `sid`.
+- Confirm Payload refresh succeeds after OAuth login with sessions enabled.
+- Confirm logout removes the session and a restored old cookie no longer authenticates.

--- a/src/auth-sessions.ts
+++ b/src/auth-sessions.ts
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import type {
+  CollectionSlug,
+  PayloadRequest,
+  User,
+  UserSession,
+} from "payload";
+
+type AuthConfigWithSessions = {
+  disableLocalStrategy?: unknown;
+  tokenExpiration?: number;
+  useSessions?: boolean;
+};
+
+type CollectionConfigWithAuthSessions = {
+  auth?: boolean | AuthConfigWithSessions;
+  slug: string;
+};
+
+type SessionAwareUser = User & {
+  _sid?: string;
+  _strategy?: string;
+  sessions?: UserSession[];
+  updatedAt?: Date | null | string;
+};
+
+const isAuthConfigWithSessions = (
+  auth: CollectionConfigWithAuthSessions["auth"],
+): auth is AuthConfigWithSessions => typeof auth === "object" && auth !== null;
+
+export const shouldUsePayloadSessions = (
+  collectionConfig: CollectionConfigWithAuthSessions,
+): boolean =>
+  isAuthConfigWithSessions(collectionConfig.auth) &&
+  collectionConfig.auth.useSessions === true &&
+  !collectionConfig.auth.disableLocalStrategy;
+
+export const removeExpiredPayloadSessions = (
+  sessions: UserSession[],
+): UserSession[] => {
+  const now = new Date();
+
+  return sessions.filter(({ expiresAt }) => {
+    const expiry = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+    return expiry > now;
+  });
+};
+
+export const userHasPayloadSession = (user: User, sid: string): boolean =>
+  Array.isArray((user as SessionAwareUser).sessions) &&
+  (user as SessionAwareUser).sessions!.some((session) => session.id === sid);
+
+export const addPayloadSessionToUser = async ({
+  collectionConfig,
+  req,
+  user,
+}: {
+  collectionConfig: CollectionConfigWithAuthSessions;
+  req: PayloadRequest;
+  user: User;
+}): Promise<string | undefined> => {
+  if (!shouldUsePayloadSessions(collectionConfig)) return undefined;
+  if (!isAuthConfigWithSessions(collectionConfig.auth)) return undefined;
+
+  const now = new Date();
+  const sid = crypto.randomUUID();
+  const tokenExpiration = collectionConfig.auth.tokenExpiration ?? 7200;
+  const session: UserSession = {
+    id: sid,
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + tokenExpiration * 1000),
+  };
+  const sessionAwareUser = user as SessionAwareUser;
+  const existingSessions = Array.isArray(sessionAwareUser.sessions)
+    ? removeExpiredPayloadSessions(sessionAwareUser.sessions)
+    : [];
+
+  sessionAwareUser.sessions = [...existingSessions, session];
+  sessionAwareUser.updatedAt = null;
+
+  await req.payload.db.updateOne({
+    id: user.id,
+    collection: collectionConfig.slug as CollectionSlug,
+    data: sessionAwareUser,
+    req,
+    returning: false,
+  });
+
+  sessionAwareUser.collection = collectionConfig.slug;
+  sessionAwareUser._sid = sid;
+
+  return sid;
+};

--- a/src/auth-strategy.ts
+++ b/src/auth-strategy.ts
@@ -6,7 +6,26 @@ import {
   User,
   extractJWT,
 } from "payload";
+import {
+  shouldUsePayloadSessions,
+  userHasPayloadSession,
+} from "./auth-sessions";
 import { PluginOptions } from "./types";
+
+const getStringClaim = (
+  jwtUser: JWTPayload,
+  claimName: string,
+): string | undefined => {
+  const claim = jwtUser[claimName];
+  return typeof claim === "string" && claim.length > 0 ? claim : undefined;
+};
+
+const getJWTUserID = (jwtUser: JWTPayload): number | string | undefined => {
+  const userID = jwtUser.id;
+  return typeof userID === "string" || typeof userID === "number"
+    ? userID
+    : undefined;
+};
 
 export const createAuthStrategy = (
   pluginOptions: PluginOptions,
@@ -41,6 +60,40 @@ export const createAuthStrategy = (
           jwtUser.collection) ||
           pluginOptions.authCollection ||
           "users") as CollectionSlug;
+        const collectionConfig = payload.collections[userCollection]?.config;
+        if (!collectionConfig) return { user: null };
+
+        if (shouldUsePayloadSessions(collectionConfig)) {
+          const sid = getStringClaim(jwtUser, "sid");
+          const userID = getJWTUserID(jwtUser);
+          if (!sid || userID === undefined) return { user: null };
+
+          const user = (await payload.findByID({
+            collection: userCollection,
+            disableErrors: true,
+            id: userID,
+            showHiddenFields: true,
+          })) as User | null;
+
+          if (!user || !userHasPayloadSession(user, sid)) {
+            return { user: null };
+          }
+
+          if (
+            typeof collectionConfig.auth === "object" &&
+            collectionConfig.auth.verify &&
+            !user._verified
+          ) {
+            return { user: null };
+          }
+
+          user.collection = userCollection;
+          user._sid = sid;
+          user._strategy = pluginOptions.strategyName;
+
+          return { user };
+        }
+
         let user: User | null = null;
 
         if (pluginOptions.useEmailAsIdentity) {
@@ -87,6 +140,7 @@ export const createAuthStrategy = (
           }
         }
         user.collection = userCollection;
+        user._strategy = pluginOptions.strategyName;
 
         // Return the user object
         return { user };

--- a/src/callback-endpoint.ts
+++ b/src/callback-endpoint.ts
@@ -12,6 +12,7 @@ import type {
   User,
 } from "payload";
 import { generatePayloadCookie, getFieldsToSign } from "payload";
+import { addPayloadSessionToUser } from "./auth-sessions";
 import { defaultCallbackExtractToken } from "./default-callback-extract-token";
 import { defaultGetToken } from "./default-get-token";
 import type { PluginOptions } from "./types";
@@ -172,9 +173,21 @@ export const createCallbackEndpoint = (
       // /////////////////////////////////////
       // login - OAuth2
       // /////////////////////////////////////
+      const sid = await addPayloadSessionToUser({
+        collectionConfig,
+        req,
+        user,
+      });
+      user.collection = authCollection;
+      user._strategy = pluginOptions.strategyName;
+      if (sid) {
+        user._sid = sid;
+      }
+
       const fieldsToSign = getFieldsToSign({
         collectionConfig,
         email: excludeEmailFromJwtToken ? "" : user.email || "",
+        sid,
         user: user as PayloadRequest["user"],
       });
 

--- a/test/__mocks__/payload.ts
+++ b/test/__mocks__/payload.ts
@@ -27,14 +27,20 @@ export type Payload = {
     debug: jest.Mock;
   };
   find: jest.Mock;
+  findByID: jest.Mock;
   create: jest.Mock;
   update: jest.Mock;
+  db: {
+    findOne: jest.Mock;
+    updateOne: jest.Mock;
+  };
 };
 
 export type AuthConfig = {
   disableLocalStrategy?: boolean;
   strategies?: unknown[];
   tokenExpiration?: number;
+  useSessions?: boolean;
 };
 
 export type CollectionConfig = {
@@ -74,6 +80,11 @@ export type RequestContext = Record<string, unknown>;
 export type CollectionSlug = string;
 export type JsonObject = Record<string, unknown>;
 export type TypeWithID = { id: string | number };
+export type UserSession = {
+  createdAt: Date | string;
+  expiresAt: Date | string;
+  id: string;
+};
 export type User = TypeWithID & Record<string, unknown>;
 export type PaginatedDocs<T> = { docs: T[] };
 export type AuthStrategyResult = { user: User | null };
@@ -146,11 +157,13 @@ export function generatePayloadCookie(options: {
 export function getFieldsToSign(options: {
   collectionConfig: CollectionConfig;
   email: string;
+  sid?: string;
   user: Record<string, unknown> | null;
 }): Record<string, unknown> {
   return {
     ...(options.user ?? {}),
     email: options.email,
+    ...(options.sid ? { sid: options.sid } : {}),
   };
 }
 

--- a/test/base-oauth-test.ts
+++ b/test/base-oauth-test.ts
@@ -123,6 +123,15 @@ export function createMockPayload(context?: OAuthTestContext): Payload {
         nextPage: null,
       };
     }),
+    findByID: jest.fn().mockImplementation(async ({ id }) => {
+      if (!context) return null;
+      return (
+        context.foundUsers.find((user) => user.id === id) ||
+        (context.createdUser?.id === id ? context.createdUser : null) ||
+        (context.updatedUser?.id === id ? context.updatedUser : null) ||
+        null
+      );
+    }),
     create: jest.fn().mockImplementation(async ({ data }) => {
       const newUser = { id: "new-user-id", ...data };
       if (context) {
@@ -137,6 +146,31 @@ export function createMockPayload(context?: OAuthTestContext): Payload {
       }
       return updatedUser;
     }),
+    db: {
+      findOne: jest.fn().mockImplementation(async ({ where }) => {
+        if (!context) return null;
+        const id = where?.id?.equals;
+        return (
+          context.foundUsers.find((user) => user.id === id) ||
+          (context.createdUser?.id === id ? context.createdUser : null) ||
+          (context.updatedUser?.id === id ? context.updatedUser : null) ||
+          null
+        );
+      }),
+      updateOne: jest.fn().mockImplementation(async ({ id, data }) => {
+        if (context) {
+          const mergeUser = (user: MockUserInfo | null) =>
+            user?.id === id ? Object.assign(user, data) : user;
+
+          context.createdUser = mergeUser(context.createdUser);
+          context.updatedUser = mergeUser(context.updatedUser);
+          context.foundUsers = context.foundUsers.map((user) =>
+            user.id === id ? Object.assign(user, data) : user,
+          );
+        }
+        return data;
+      }),
+    },
   };
 
   return mockPayload as Payload;

--- a/test/callback-endpoint.spec.ts
+++ b/test/callback-endpoint.spec.ts
@@ -1,3 +1,4 @@
+import { SignJWT, jwtVerify } from "jose";
 import type { PayloadRequest } from "payload";
 import { createAuthStrategy } from "../src/auth-strategy";
 import { createCallbackEndpoint } from "../src/callback-endpoint";
@@ -230,6 +231,141 @@ describe("Callback endpoint unit flow", () => {
         sub: "provider-user-123",
       }),
     );
+  });
+
+  it("creates a Payload session and signs its sid when sessions are enabled", async () => {
+    const context = createMockOAuthTestContext({ foundUsers: [] });
+    const req = createCallbackRequest(context);
+    req.payload.collections.users.config.auth = {
+      tokenExpiration: 7200,
+      useSessions: true,
+    };
+    let issuedToken = "";
+    const pluginOptions = basePluginOptions({
+      successRedirect: jest.fn((_req, token) => {
+        issuedToken = token;
+        return "/admin";
+      }),
+    });
+
+    const response = (await getGetCallbackHandler(pluginOptions)(
+      req,
+    )) as Response;
+
+    expect(response.status).toBe(302);
+    expect(req.payload.db.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "users",
+        id: "new-user-id",
+        returning: false,
+      }),
+    );
+    expect(context.createdUser?.sessions).toEqual([
+      expect.objectContaining({
+        id: expect.any(String),
+        createdAt: expect.any(Date),
+        expiresAt: expect.any(Date),
+      }),
+    ]);
+
+    const sid = context.createdUser?.sessions?.[0]?.id;
+    const { payload } = await jwtVerify(
+      issuedToken,
+      new TextEncoder().encode(req.payload.secret),
+    );
+    expect(payload.sid).toBe(sid);
+    expect(req.user).toEqual(expect.objectContaining({ _sid: sid }));
+  });
+
+  it("validates session-backed callback JWTs through the auth strategy", async () => {
+    const context = createMockOAuthTestContext({ foundUsers: [] });
+    const req = createCallbackRequest(context);
+    req.payload.collections.users.config.auth = {
+      tokenExpiration: 7200,
+      useSessions: true,
+    };
+    let issuedToken = "";
+    const pluginOptions = basePluginOptions({
+      successRedirect: jest.fn((_req, token) => {
+        issuedToken = token;
+        return "/admin";
+      }),
+    });
+
+    await getGetCallbackHandler(pluginOptions)(req);
+    context.foundUsers = [context.createdUser!];
+    req.payload.find.mockClear();
+    req.payload.create.mockClear();
+
+    const authStrategy = createAuthStrategy(pluginOptions, "sub");
+    const result = await authStrategy.authenticate({
+      headers: new Headers({ Authorization: `Bearer ${issuedToken}` }),
+      payload: req.payload,
+    });
+
+    const sid = context.createdUser?.sessions?.[0]?.id;
+    expect(req.payload.findByID).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "users",
+        id: "new-user-id",
+        showHiddenFields: true,
+      }),
+    );
+    expect(req.payload.find).not.toHaveBeenCalled();
+    expect(req.payload.create).not.toHaveBeenCalled();
+    expect(result.user).toEqual(
+      expect.objectContaining({
+        _sid: sid,
+        _strategy: "unit-test-provider",
+        collection: "users",
+        email: "new-user@example.com",
+      }),
+    );
+  });
+
+  it.each([
+    { name: "missing sid", sid: undefined },
+    { name: "revoked sid", sid: "revoked-session-id" },
+  ])("rejects session-backed JWTs with $name", async ({ sid }) => {
+    const context = createMockOAuthTestContext({
+      foundUsers: [
+        {
+          id: "existing-user-id",
+          email: "existing-user@example.com",
+          sub: "provider-user-123",
+          sessions: [
+            {
+              id: "valid-session-id",
+              createdAt: new Date(),
+              expiresAt: new Date(Date.now() + 7200 * 1000),
+            },
+          ],
+        },
+      ],
+    });
+    const req = createCallbackRequest(context);
+    req.payload.collections.users.config.auth = {
+      tokenExpiration: 7200,
+      useSessions: true,
+    };
+    const token = await new SignJWT({
+      id: "existing-user-id",
+      collection: "users",
+      email: "existing-user@example.com",
+      ...(sid ? { sid } : {}),
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setExpirationTime("7200 secs")
+      .sign(new TextEncoder().encode(req.payload.secret));
+
+    const authStrategy = createAuthStrategy(basePluginOptions(), "sub");
+    const result = await authStrategy.authenticate({
+      headers: new Headers({ Authorization: `Bearer ${token}` }),
+      payload: req.payload,
+    });
+
+    expect(result.user).toBeNull();
+    expect(req.payload.create).not.toHaveBeenCalled();
   });
 
   it("passes PKCE verifier cookie into the default token exchange", async () => {


### PR DESCRIPTION
## Summary

- create Payload session records during OAuth callback when Payload sessions are active
- include the session `sid` in OAuth-issued Payload JWTs and validate it in the auth strategy
- reject sid-less or revoked session JWTs instead of recreating users from them
- move project instruction files under `docs/instructions` and add session troubleshooting guidance

Closes #52
Closes #62

## Tests

- `corepack pnpm build`
- `corepack pnpm test`
