### PR TITLE
fix(auth): avoid persisting populated relationship fields in OAuth session write

### DIFF
--- a/src/auth-sessions.ts
+++ b/src/auth-sessions.ts
@@ -74,14 +74,18 @@ export const addPayloadSessionToUser = async ({
   const existingSessions = Array.isArray(sessionAwareUser.sessions)
     ? removeExpiredPayloadSessions(sessionAwareUser.sessions)
     : [];
+  const nextSessions = [...existingSessions, session];
 
-  sessionAwareUser.sessions = [...existingSessions, session];
+  sessionAwareUser.sessions = nextSessions;
   sessionAwareUser.updatedAt = null;
 
   await req.payload.db.updateOne({
     id: user.id,
     collection: collectionConfig.slug as CollectionSlug,
-    data: sessionAwareUser,
+    data: {
+      sessions: nextSessions,
+      updatedAt: null,
+    },
     req,
     returning: false,
   });

--- a/test/callback-endpoint.spec.ts
+++ b/test/callback-endpoint.spec.ts
@@ -277,6 +277,53 @@ describe("Callback endpoint unit flow", () => {
     expect(req.user).toEqual(expect.objectContaining({ _sid: sid }));
   });
 
+  it("does not persist populated relationship fields when creating Payload sessions", async () => {
+    const context = createMockOAuthTestContext({ foundUsers: [] });
+    const req = createCallbackRequest(context);
+    req.payload.collections.users.config.auth = {
+      tokenExpiration: 7200,
+      useSessions: true,
+    };
+    req.payload.collections.users.config.hooks = {
+      beforeLogin: [
+        ({ user }) => ({
+          ...(user as Record<string, unknown>),
+          roles: [
+            {
+              id: "6798c5c9c99e8d8d3d3b9be5",
+              slug: "admin",
+              name: "Admin",
+            },
+          ],
+        }),
+      ],
+      afterLogin: [],
+    };
+
+    const pluginOptions = basePluginOptions();
+    const response = (await getGetCallbackHandler(pluginOptions)(
+      req,
+    )) as Response;
+
+    expect(response.status).toBe(302);
+
+    const updateCall = (req.payload.db.updateOne as jest.Mock).mock
+      .calls[0]?.[0];
+    expect(updateCall).toEqual(
+      expect.objectContaining({
+        collection: "users",
+        id: "new-user-id",
+      }),
+    );
+    expect(updateCall.data).toEqual(
+      expect.objectContaining({
+        sessions: expect.any(Array),
+        updatedAt: null,
+      }),
+    );
+    expect(updateCall.data).not.toHaveProperty("roles");
+  });
+
   it("validates session-backed callback JWTs through the auth strategy", async () => {
     const context = createMockOAuthTestContext({ foundUsers: [] });
     const req = createCallbackRequest(context);


### PR DESCRIPTION
## Summary

This PR fixes a regression in OAuth callback session persistence where the plugin writes the full `user` object via `db.updateOne` when adding a Payload session.

In projects with populated relationship fields (e.g. `roles`) on the user during login hooks, this can persist relationship objects instead of IDs and trigger Mongo cast errors like:

- `Cast to [ObjectId] failed ... at path "roles.0"`

## Root Cause

`addPayloadSessionToUser` currently passes a user-shaped object into session persistence, which can include populated relationship data from login hooks.

## Fix

Update `addPayloadSessionToUser` to persist only session-related fields:

- `sessions`
- `updatedAt`

while still mutating the in-memory user with session info for downstream token signing.

## Tests

Added regression coverage in `test/callback-endpoint.spec.ts`:

- `does not persist populated relationship fields when creating Payload sessions`

This test simulates a populated `roles` array injected in `beforeLogin` and asserts that `db.updateOne` payload does **not** include `roles`.

## Verification

Ran targeted test suite:

- `pnpm test -- callback-endpoint.spec.ts`
- Result: all tests passing (15/15)

